### PR TITLE
WIP: adding daemon and cleaning up hostmanager

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,8 @@ vagrant up --provision-with setup app
 ### Subsequent Runs
 Once you already have everything setup for the app, you can simply run `vagrant up`. If you only need the application, and have your own SQL server, redis, and mailhog (or some combination), you can run `vagrant up [boxes]` and replace `[boxes]` with the boxes to bring online.
 
+### Daemons
+There are VMs for both, the old and the new, daemons configured. They do not start automatically. You can start them using `vagrant up daemon` (for the nodejs one) and `vagrant up wings` (the golang one).
+
 ### Updating /etc/hosts
 On your first run, and whenever the hostnames change, you'll have to run `vagrant hostmanager app --provider docker` to update your /etc/hosts file.

--- a/README.md
+++ b/README.md
@@ -19,3 +19,6 @@ vagrant up --provision-with setup app
 
 ### Subsequent Runs
 Once you already have everything setup for the app, you can simply run `vagrant up`. If you only need the application, and have your own SQL server, redis, and mailhog (or some combination), you can run `vagrant up [boxes]` and replace `[boxes]` with the boxes to bring online.
+
+### Updating /etc/hosts
+On your first run, and whenever the hostnames change, you'll have to run `vagrant hostmanager app --provider docker` to update your /etc/hosts file.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -66,7 +66,6 @@ Vagrant.configure("2") do |config|
 			owner: "vagrant", group: "vagrant"
 
 		wings.vm.network :private_network, ip: "192.168.50.3"
-		wings.vm.network :forwarded_port, guest: 8080, host: 58080
 
 		wings.vm.provision "provision", type: "shell", path: "#{vagrant_root}/scripts/provision_wings.sh"
 	end
@@ -81,8 +80,6 @@ Vagrant.configure("2") do |config|
 		daemon.vm.synced_folder ".data/daemon-data", "/srv/daemon-data", create: true
 
 		daemon.vm.network :private_network, ip: "192.168.50.4"
-		daemon.vm.network :forwarded_port, guest: 8080, host: 58081
-		daemon.vm.network :forwarded_port, guest: 8022, host: 58022
 
 		daemon.vm.provision "provision", type: "shell", path: "#{vagrant_root}/scripts/provision_daemon.sh"
 	end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -74,6 +74,22 @@ Vagrant.configure("2") do |config|
 		wings.vm.provision "provision", type: "shell", path: "#{vagrant_root}/scripts/provision_wings.sh"
 	end
 
+	config.vm.define "daemon", autostart: false do |daemon|
+		daemon.vm.hostname = "daemon.pterodactyl.test"
+		daemon.vm.box = "bento/ubuntu-18.04"
+
+		daemon.vm.synced_folder ".", "/vagrant", disabled: true
+		daemon.vm.synced_folder "#{vagrant_root}/code/daemon", "/srv/daemon", owner: "vagrant", group: "vagrant"
+		daemon.vm.synced_folder "#{vagrant_root}/code/sftp-server", "/home/vagrant/go/src/github.com/pterodactyl/sftp-server", owner: "vagrant", group: "vagrant"
+		daemon.vm.synced_folder ".data/daemon-data", "/srv/daemon-data", create: true
+
+		daemon.vm.network :private_network, ip: "192.168.50.4"
+		daemon.vm.network :forwarded_port, guest: 8080, host: 58081
+		daemon.vm.network :forwarded_port, guest: 8022, host: 58022
+
+		daemon.vm.provision "provision", type: "shell", path: "#{vagrant_root}/scripts/provision_daemon.sh"
+	end
+
 	config.vm.define "docs" do |docs|
 		docs.vm.hostname = "documentation"
 		docs.vm.synced_folder ".", "/vagrant", disabled: true

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -157,7 +157,7 @@ Vagrant.configure("2") do |config|
 	# Create a docker container for mailhog which providers a local SMTP environment that avoids actually
 	# sending emails to the address.
 	config.vm.define "mailhog" do |mh|
-		mh.vm.hostname = "mailhog"
+		mh.vm.hostname = "mailhog.pterodactl.test"
 		mh.vm.synced_folder ".", "/vagrant", disabled: true
 
 		mh.vm.network "forwarded_port", guest: 1025, host: 1025

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,7 +28,8 @@ Vagrant.configure("2") do |config|
 
 		app.vm.provider "docker" do |d|
 			d.image = "quay.io/pterodactyl/vagrant-panel"
-			d.create_args = ["-it", "--add-host=host.pterodactyl.test:172.17.0.1"]
+			d.create_args = ["-it", "--add-host=host.pterodactyl.test:172.17.0.1", 
+				"--add-host=daemon.pterodactyl.test:192.168.50.4", "--add-host=wings.pterodactyl.test:192.168.50.3"]
 			d.ports = ["80:80", "8080:8080", "8081:8081"]
 
 			if ENV['FILE_SYNC_METHOD'] === 'docker-sync'
@@ -41,6 +42,7 @@ Vagrant.configure("2") do |config|
 			d.has_ssh = true
 		end
 
+		app.vm.provision :hostmanager
 		app.vm.provision "deploy_files", type: "file", source: "#{vagrant_root}/build/configs", destination: "/tmp/.deploy"
 		app.vm.provision "configure_application", type: "shell", path: "#{vagrant_root}/scripts/deploy_app.sh"
 		app.vm.provision "setup", type: "shell", run: "never", inline: <<-SHELL

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -157,7 +157,7 @@ Vagrant.configure("2") do |config|
 	# Create a docker container for mailhog which providers a local SMTP environment that avoids actually
 	# sending emails to the address.
 	config.vm.define "mailhog" do |mh|
-		mh.vm.hostname = "mailhog.pterodactl.test"
+		mh.vm.hostname = "mailhog.pterodactyl.test"
 		mh.vm.synced_folder ".", "/vagrant", disabled: true
 
 		mh.vm.network "forwarded_port", guest: 1025, host: 1025

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -78,7 +78,7 @@ Vagrant.configure("2") do |config|
 
 		daemon.vm.synced_folder ".", "/vagrant", disabled: true
 		daemon.vm.synced_folder "#{vagrant_root}/code/daemon", "/srv/daemon", owner: "vagrant", group: "vagrant"
-		daemon.vm.synced_folder "#{vagrant_root}/code/sftp-server", "/home/vagrant/go/src/github.com/pterodactyl/sftp-server", owner: "vagrant", group: "vagrant"
+		daemon.vm.synced_folder "#{vagrant_root}/code/sftp-server", "/home/vagrant/sftp-server", owner: "vagrant", group: "vagrant"
 		daemon.vm.synced_folder ".data/daemon-data", "/srv/daemon-data", create: true
 
 		daemon.vm.network :private_network, ip: "192.168.50.4"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,18 +7,16 @@ end
 vagrant_root = File.dirname(__FILE__)
 
 Vagrant.configure("2") do |config|
-	config.hostmanager.enabled = true
+	config.hostmanager.enabled = false
 	config.hostmanager.manage_host = true
 	config.hostmanager.manage_guest = false
 	config.hostmanager.ignore_private_ip = false
 	config.hostmanager.include_offline = true
 
 	config.vm.define "app", primary: true do |app|
-		app.vm.hostname = "app"
+		app.vm.hostname = "pterodactyl.test"
 
 		app.vm.synced_folder ".", "/vagrant", disabled: true
-
-		app.hostmanager.aliases = %w(pterodactyl.test)
 
 		app.vm.network "forwarded_port", guest: 80, host: 80
 		app.vm.network "forwarded_port", guest: 8080, host: 8080
@@ -90,10 +88,9 @@ Vagrant.configure("2") do |config|
 	end
 
 	config.vm.define "docs" do |docs|
-		docs.vm.hostname = "documentation"
+		docs.vm.hostname = "docs.pterodactyl.test"
 		docs.vm.synced_folder ".", "/vagrant", disabled: true
 
-		docs.hostmanager.aliases = %w(pterodocs.test)
 		docs.vm.network "forwarded_port", guest: 80, host: 9090
 		docs.vm.network "forwarded_port", guest: 9091, host: 9091
 
@@ -118,12 +115,11 @@ Vagrant.configure("2") do |config|
 
 	# Configure a mysql docker container.
 	config.vm.define "mysql" do |mysql|
-		mysql.vm.hostname = "mysql"
+		mysql.vm.hostname = "mysql.pterodactyl.test"
 		mysql.vm.synced_folder ".", "/vagrant", disabled: true
 		mysql.vm.synced_folder ".data/mysql", "/var/lib/mysql", create: true
 
 		mysql.vm.network "forwarded_port", guest: 3306, host: 3306
-		mysql.hostmanager.aliases = %w(mysql.pterodactyl.test)
 
 		mysql.vm.provider "docker" do |d|
 			d.image = "mysql:5.7"
@@ -147,12 +143,11 @@ Vagrant.configure("2") do |config|
 	end
 
 	config.vm.define "chromedriver" do |chrome|
-		chrome.vm.hostname = "chromedriver"
+		chrome.vm.hostname = "chromedriver.pterodactyl.test"
 		chrome.vm.synced_folder ".", "/vagrant", disabled: true
 
 		chrome.vm.network "forwarded_port", guest: 4444, host: 4444
 		chrome.vm.network "forwarded_port", guest: 5900, host: 5900
-		chrome.hostmanager.aliases = %w(chrome.pterodactyl.test)
 
 		chrome.vm.provider "docker" do |d|
 			d.image = "selenium/standalone-chrome-debug:3.12.0-boron"
@@ -170,7 +165,6 @@ Vagrant.configure("2") do |config|
 
 		mh.vm.network "forwarded_port", guest: 1025, host: 1025
 		mh.vm.network "forwarded_port", guest: 8025, host: 8025
-		mh.hostmanager.aliases = %w(mailhog.pterodactyl.test)
 
 		mh.vm.provider "docker" do |d|
 			d.image = "mailhog/mailhog"
@@ -181,13 +175,10 @@ Vagrant.configure("2") do |config|
 
 	# Create a docker container for the redis server.
 	config.vm.define "redis" do |redis|
-		redis.vm.hostname = "redis"
+		redis.vm.hostname = "redis.pterodactyl.test"
 		redis.vm.synced_folder ".", "/vagrant", disabled: true
 
 		redis.vm.network "forwarded_port", guest: 6379, host: 6379
-		redis.hostmanager.aliases = %w(redis.pterodactyl.test)
-
-		redis.vm.provision :hostmanager
 
 		redis.vm.provider "docker" do |d|
 			d.image = "redis:4.0-alpine"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -60,16 +60,15 @@ Vagrant.configure("2") do |config|
 	end
 
 	config.vm.define "wings", autostart: false do |wings|
-		wings.vm.hostname = "wings"
-	
+		wings.vm.hostname = "wings.pterodactyl.test"
 		wings.vm.box = "bento/ubuntu-18.04"
 
 		wings.vm.synced_folder ".", "/vagrant", disabled: true
 		wings.vm.synced_folder "#{vagrant_root}/code/wings", "/home/vagrant/go/src/github.com/pterodactyl/wings",
 			owner: "vagrant", group: "vagrant"
 
+		wings.vm.network :private_network, ip: "192.168.50.3"
 		wings.vm.network :forwarded_port, guest: 8080, host: 58080
-		wings.hostmanager.aliases = %w(wings.test)
 
 		wings.vm.provision "provision", type: "shell", path: "#{vagrant_root}/scripts/provision_wings.sh"
 	end

--- a/build/configs/nginx/pterodactyl.test.conf
+++ b/build/configs/nginx/pterodactyl.test.conf
@@ -41,3 +41,26 @@ server {
         deny all;
     }
 }
+
+server {
+	listen 80;
+
+	index index.html;
+	server_name docs.pterodactyl.test;
+
+	location / {
+		proxy_pass http://host.pterodactyl.test:9090;
+	}
+
+	# security headers
+	add_header X-Frame-Options "SAMEORIGIN" always;
+	add_header X-XSS-Protection "1; mode=block" always;
+	add_header X-Content-Type-Options "nosniff" always;
+	add_header Referrer-Policy "same-origin" always;
+	add_header Content-Security-Policy "default-src * data: 'unsafe-eval' 'unsafe-inline'" always;
+	
+	# . files
+	location ~ /\. {
+		deny all;
+	}
+}

--- a/build/configs/nginx/pterodocs.test.conf
+++ b/build/configs/nginx/pterodocs.test.conf
@@ -2,7 +2,7 @@ server {
 	listen 80;
 
 	index index.html;
-	server_name pterodocs.test;
+	server_name docs.pterodactyl.test;
 	root /srv/documentation/.vuepress/dist;
 
 	location / {

--- a/scripts/provision_daemon.sh
+++ b/scripts/provision_daemon.sh
@@ -6,6 +6,7 @@ echo "Provisioning development environment for Pterodactyl Panel."
 echo "Add repositories"
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add - > /dev/null
 add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /dev/null
+add-apt-repository -y ppa:longsleep/golang-backports > /dev/null
 curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash - > /dev/null
 curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
 echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list

--- a/scripts/provision_daemon.sh
+++ b/scripts/provision_daemon.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+export DEBIAN_FRONTEND=noninteractive
+
+echo "Provisioning development environment for Pterodactyl Panel."
+
+echo "Add repositories"
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add - > /dev/null
+add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /dev/null
+curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash - > /dev/null
+curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+apt-get update
+
+echo "Install everything"
+apt-get -y install nodejs yarn \
+    golang-go mercurial \
+    docker-ce docker-ce-cli containerd.io \
+    tar unzip make gcc g++ python > /dev/null
+
+systemctl enable docker
+systemctl start docker
+
+usermod -aG docker vagrant
+
+echo "Install ctop for fancy container monitoring"
+wget https://github.com/bcicen/ctop/releases/download/v0.7.2/ctop-0.7.2-linux-amd64 -q -O /usr/local/bin/ctop
+chmod +x /usr/local/bin/ctop
+
+echo "Setup GOPATH"
+echo "export GOPATH=/home/vagrant/go" >> /home/vagrant/.profile
+export GOPATH=/go
+echo 'export PATH=$PATH:$GOPATH/bin' >> /home/vagrant/.profile
+
+echo "Install nodejs dependencies"
+$(cd /srv/daemon && yarn install)
+
+echo "   ------------"
+echo "Provisioning is completed."
+echo "You'll still need to configure your node in the panel manually."

--- a/scripts/provision_wings.sh
+++ b/scripts/provision_wings.sh
@@ -4,9 +4,12 @@ export DEBIAN_FRONTEND=noninteractive
 chown -R vagrant:vagrant /home/vagrant
 
 echo "Install docker, go and some dependencies"
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add - > /dev/null
+add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /dev/null
+add-apt-repository -y ppa:longsleep/golang-backports > /dev/null
 apt-get -qq update
 apt-get -qq -o=Dpkg::Use-Pty=0 upgrade
-apt-get -qq -o=Dpkg::Use-Pty=0 install -y golang-go docker.io mercurial tar unzip make gcc g++ python
+apt-get -qq -o=Dpkg::Use-Pty=0 install -y golang-go docker-ce mercurial tar unzip make gcc g++ python
 
 usermod -aG docker vagrant
 

--- a/setup.sh
+++ b/setup.sh
@@ -10,6 +10,8 @@ cd $currentDirectory
 git clone https://github.com/pterodactyl/panel.git code/panel
 git clone https://github.com/pterodactyl/documentation.git code/documentation
 git clone https://github.com/pterodactyl/wings.git code/wings
+git clone https://github.com/pterodactyl/daemon.git code/daemon
+git clone https://github.com/pterodactyl/sftp-server.git code/sftp-server
 
 # sudo gem install docker-sync
 # docker-sync start


### PR DESCRIPTION
This PR adds a VM for the nodejs daemon. It is a VM so we don't litter the host with docker containers created by the daemon, it's the same for wings. Both don't autostart.
The daemon VM also contains golang for the standalone sftp.

This PR also disables hostmanager by default and requires to run it manually.
The reason for this is that the hostmanager overrides /etc/hosts when starting the individual VMs and leaves out the docker containers' hostnames for whatever reason.
When using `vagrant hostmanager app --provider docker` it sets all hostnames correctly.

I've also set the various pterodactyl.test hostnames to everything directly to avoid useless entries in /etc/hosts and renamed pterodocs.test to docs.pterodactyl.test.

This also adds the nginx reverse proxy configuration to the app container's nginx, so docs.pterodactyl.test is actually reachable.