### PR TITLE
Update Dockerfile to use NodeJS 16

### DIFF
--- a/build/panel/Dockerfile
+++ b/build/panel/Dockerfile
@@ -10,7 +10,7 @@ ENV LANG=C.UTF-8
 USER root
 RUN apt -y update \
     && apt -y --no-install-recommends install lsb-release ca-certificates apt-transport-https software-properties-common gnupg2 curl sudo  \
-    && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
+    && curl -sL https://deb.nodesource.com/setup_16.x | bash - \
 	&& curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
 	&& echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
     && echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/sury-php.list \


### PR DESCRIPTION
Bumps version of NodeJS from version 14 to version 16.

Resolves #14 with out of date NodeJS install.