### PR TITLE
fix: bump go version to 1.21.8

### DIFF
--- a/build/wings/Dockerfile
+++ b/build/wings/Dockerfile
@@ -27,8 +27,8 @@ RUN apt -y update \
         containerd.io \
         iproute2 \
         net-tools \
-    && curl -OL "https://go.dev/dl/go1.18.7.linux-$(dpkg --print-architecture).tar.gz" \
-    && tar xvf "go1.18.7.linux-$(dpkg --print-architecture).tar.gz" -C /usr/local \
+    && curl -OL "https://go.dev/dl/go1.21.8.linux-$(dpkg --print-architecture).tar.gz" \
+    && tar xvf "go1.21.8.linux-$(dpkg --print-architecture).tar.gz" -C /usr/local \
     && chown -R root:root /usr/local/go \
     && rm -rf go*.gz \
     && /usr/local/go/bin/go install github.com/go-delve/delve/cmd/dlv@latest \


### PR DESCRIPTION
Required version in wings's go.mod is 1.21 so bump go version, fix #17 
